### PR TITLE
Fix KMS outbound firewall rule bug

### DIFF
--- a/jobs/set_kms_host/templates/pre-start.ps1.erb
+++ b/jobs/set_kms_host/templates/pre-start.ps1.erb
@@ -20,7 +20,7 @@ if ((Get-NetFirewallRule | where { $_.DisplayName -eq $InboundRule }) -eq $null)
 $OutboundRule="Open outbound $DesiredPort for KMS Server"
 if ((Get-NetFirewallRule | where { $_.DisplayName -eq $OutboundRule }) -eq $null) {
     "Creating outbound firewall rule for KMS"
-    netsh advfirewall firewall add rule name=$OutboundRule dir=out action=allow protocol=TCP localport=$DesiredPort
+    netsh advfirewall firewall add rule name=$OutboundRule dir=out action=allow protocol=TCP remoteport=$DesiredPort
 } else {
     "Outbound firewall rule for KMS already exists"
 }


### PR DESCRIPTION
Change outbound firewall rule from localport to remoteport.  It will not work if the outbound rule only allows traffic out with the desired port as the source port - it needs to be the destination port.